### PR TITLE
Exempt mip sdk from cla

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -2,6 +2,9 @@ name: Contributor License Agreement Policy
 description: CLA policy file
 
 resource: repository
+where:
+- |
+  !repository.name.equals("mip-sdk-for-cpp", StringComparison.InvariantCultureIgnoreCase)
 
 configuration: 
    cla:


### PR DESCRIPTION
MIP SDK is not open source, so does not need to sign CLA for open source software